### PR TITLE
Adds a function to bind directly on an existing UDP socket

### DIFF
--- a/lib/udt4/pyudt.py
+++ b/lib/udt4/pyudt.py
@@ -113,14 +113,18 @@ class UdtSocket(object):
         return UdtSocket(_sock = accept[0]), accept[1] 
 
 
-    def bind(self, address):
+    def bind(self, arg):
         """
-        Binds port to device associted with address and specific port.
+        Binds the UDT socket to address and specific port OR binds 
+	UDT directly on an existing UDP socket.
 
-        :param  address:    device ip port pair  
-        :type   address:    tuple( str(), int() )
+        :param  arg:    device ip port pair or an existing UDP socket  
+        :type   arg:    tuple( str(), int() ) or a UDP socket.socket
         """
-        udt4.bind(self.__sock, str(address[0]), int(address[1]))
+	if isinstance(arg,socklib.socket):
+		udt4.bind_to_udp(self.__sock,arg.fileno())
+	else:
+        	udt4.bind(self.__sock, str(arg[0]), int(arg[1]))
         
 
     def close(self):

--- a/src/py-udt4.cc
+++ b/src/py-udt4.cc
@@ -465,7 +465,7 @@ pyudt4_bind_to_udp(PyObject *py_self, PyObject *args)
                 return 0x0; 
         }
 
-        if (UDT::ERROR == UDT::bind(sock->sock, udp_sock))
+        if (UDT::ERROR == UDT::bind2(sock->sock, udp_sock))
                 RETURN_UDT_RUNTIME_ERROR;
 
         Py_RETURN_NONE;


### PR DESCRIPTION
The function was already implemented on the c++ end and linked to a corresponding python function but it was never used. I modified the bind function in order to implement it.
I also modified the c++ bind_to_udp function to match the API of UDT 4.11 which uses bind2 instead of bind when using an existing UDP socket.
